### PR TITLE
DEV-1804: Update scripts/bc-wp-init.sh to add .local part for WP website domain name

### DIFF
--- a/scripts/bc-wp-init.sh
+++ b/scripts/bc-wp-init.sh
@@ -2,7 +2,9 @@
 
 cp ./provision/default.yml ./site.yml
 printf "Domain name (eg. promocode.co.ke): "; read domain
-sed -i -e "/hostname:/s/.*/hostname: $domain/" site.yml
+local_domain="$domain.local"
+echo   "Your local site will be named like $local_domain"
+sed -i -e "/hostname:/s/.*/hostname: $local_domain/" site.yml
 
 echo -n "Do you want to use PHP 5.6 instead of PHP 7.0 (y/N)?"
 read php_ans
@@ -18,8 +20,8 @@ if echo "$answer" | grep -iq "^y" ;then
     echo -e "\nInstallation steps: "
     echo "1) Run '$ vagrant up' and make sure to provision."
     echo "2) Replace the files from the existing Wordpress application with the files in ./wordpress/, except ./wordpress/phpmyadmin directory."
-    echo "3) Login to phpMyAdmin at http://$domain/phpmyadmin, on database 'wordpress', with username 'wordpress' and password 'wordpress', and import your existing database. Make sure your wp-config.php matches these database credentials."
-    echo "4) Enjoy developing with your files at ./wordpress/ shared with vm folder /var/www/html, with local access at http://$domain."
+    echo "3) Login to phpMyAdmin at http://$local_domain/phpmyadmin, on database 'wordpress', with username 'wordpress' and password 'wordpress', and import your existing database. Make sure your wp-config.php matches these database credentials."
+    echo "4) Enjoy developing with your files at ./wordpress/ shared with vm folder /var/www/html, with local access at http://$local_domain."
 else
     printf "Website title: "; read title
     sed -i -e "/title:/s/.*/title: $title/" site.yml
@@ -38,6 +40,6 @@ else
 
     echo -e "\nInstallation Steps:"
     echo "1) Run '$ vagrant up' and make sure to provision."
-    echo "2) Enjoy developing with your files at ./wordpress/ shared with vm folder /var/www/html, with local access at http://$domain."
-    echo "3) You can manage the database from phpMyAdmin at http://$domain/phpmyadmin with database 'wordpress', with username 'wordpress' and password 'wordpress'."
+    echo "2) Enjoy developing with your files at ./wordpress/ shared with vm folder /var/www/html, with local access at http://$local_domain."
+    echo "3) You can manage the database from phpMyAdmin at http://$local_domain/phpmyadmin with database 'wordpress', with username 'wordpress' and password 'wordpress'."
 fi


### PR DESCRIPTION
Made small fix of scripts/bc-wp-init.sh file.
Local site will be called like youdomain.tld.local where youdomain.tld is domain name which was set first step of bc-wp-init.sh executing. 
If vagrant-hostsupdater plugin works (on Windows with vagrant running inside WSL it doesn't work properly) new line
`ip_address_of_vm youdomain.tld.local`
will be added automatically, for instance:
```
cat /etc/hosts
...
192.168.33.10  bethome.com.cy.local  # VAGRANT: 606ca3a623bf402df8b46492040c932f
```