### PR TITLE
Dev-1810

### DIFF
--- a/scripts/bc-wp-init.sh
+++ b/scripts/bc-wp-init.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-
 cp ./provision/default.yml ./site.yml
 while [[ -z $domain ]]; do
     printf "Domain name (eg. promocode.co.ke): "; read domain
@@ -35,6 +34,10 @@ fi
 
 echo "Address $ip will be used for new vagrant box"
 sed -i -e "/^ip:/s/.*/ip: $ip/" site.yml
+
+forwarded_port=`python -c "import random; print random.randint(8000,8999)"`
+
+sed -i -e "/^forwarded_port:/s/.*/forwarded_port: $forwarded_port/" site.yml
 
 echo -n "Do you want to work on an existing Wordpress website (y/n)?"
 read answer

--- a/scripts/bc-wp-init.sh
+++ b/scripts/bc-wp-init.sh
@@ -17,9 +17,9 @@ fi
 echo "Evaluating ip address for new vagrant box..."
 nextip(){
     IP=$1
-    IP_HEX=$(printf '%.2X%.2X%.2X%.2X\n' `echo $IP | sed -e 's/\./ /g'`)
+    IP_HEX=$(printf '%.2X%.2X%.2X%.2X\n' `echo $IP | sed 's/\./ /g'`)
     NEXT_IP_HEX=$(printf %.8X `echo $(( 0x$IP_HEX + 1 ))`)
-    NEXT_IP=$(printf '%d.%d.%d.%d\n' `echo $NEXT_IP_HEX | sed -r 's/(..)/0x\1 /g'`)
+    NEXT_IP=$(printf '%d.%d.%d.%d\n' `echo $NEXT_IP_HEX | sed 's/../0x& /g'`)
     echo "$NEXT_IP"
 }
 


### PR DESCRIPTION
Fixes of scripts/bc-wp-init.sh script.
We need to assign different ip addresses for vm box in case if several vm box are running at the same time.
So I added parsing of /etc/hosts file, if there are already host(s) with address 192.168.33.xxx, then we will assign new vm next suitable ip address.
Also vagrant uses forwarded_port option, and it definitely should be unique across all vms, so this option is generated randomly. 